### PR TITLE
Adds babel config override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@heronsystems/metro-with-symlinks",
-    "version": "2.0.2",
+    "version": "3.0.0-beta.0",
     "description": "Extension to metro packager enabling the use of symlinks.",
     "license": "MIT",
     "author": "@MrLoh",
@@ -14,7 +14,8 @@
     "repository": "https://github.com/heronsystems/metro-with-symlinks",
     "scripts": {
         "format": "prettier --write --list-different '**/*.js'",
-        "test": "format"
+        "test": "format",
+        "prepublish": "git push && git push --tags"
     },
     "dependencies": {
         "dedent-js": "^1.0.1"

--- a/src/getMetroConfig.js
+++ b/src/getMetroConfig.js
@@ -33,6 +33,8 @@ module.exports = symlinkedDependencies => {
         getDependencyPath,
     )
 
+    console.log(symlinkedDependenciesPaths)
+
     const peerDependenciesOfSymlinkedDependencies = symlinkedDependenciesPaths
         .map(path => require(`${path}/package.json`).peerDependencies)
         .map(peerDependencies =>

--- a/src/getSymlinkedDependencies.js
+++ b/src/getSymlinkedDependencies.js
@@ -9,11 +9,14 @@ const isSymlink = dependency => {
 }
 
 module.exports = directory => {
-    const pacakgeJson = require(`${directory}/package.json`)
-    return [
-        ...Object.keys(pacakgeJson.devDependencies || {}),
-        ...Object.keys(pacakgeJson.dependencies || {}),
+    const packageJson = require(`${directory}/package.json`)
+    const symlinks = [
+        ...Object.keys(packageJson.devDependencies || {}),
+        ...Object.keys(packageJson.dependencies || {}),
+        ...Object.keys(packageJson.peerDependencies || {}),
     ]
         .filter(isSymlink)
         .filter(dep => fs.existsSync(`node_modules/${dep}`))
+    console.log(symlinks)
+    return symlinks
 }


### PR DESCRIPTION
With how our project is structured, we need to set resolvers for packages that may be dependencies of other dependencies. This feature overrides the default babel.config.js to add these resolvers to ensure all packages are using the same version of the symlinked package.